### PR TITLE
Bump maven-bundle-plugin to allow building with Java 17+

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.4</version>
                 <configuration>
                     <instructions>
                         <Bundle-Version>${spec.bundle.version}</Bundle-Version>


### PR DESCRIPTION
Currently used plugin with Java 17 gives
```
[INFO] --- maven-bundle-plugin:4.2.1:manifest (bundle-manifest) @ jakarta.jms-api ---
[ERROR] An internal error occurred
java.util.ConcurrentModificationException
    at java.util.TreeMap.callMappingFunctionWithCheck (TreeMap.java:750)
    at java.util.TreeMap.computeIfAbsent (TreeMap.java:604)
    at aQute.bnd.osgi.Jar.putResource (Jar.java:288)
    at aQute.bnd.osgi.Jar$1.visitFile (Jar.java:202)
    at aQute.bnd.osgi.Jar$1.visitFile (Jar.java:177)
...
```