### PR TITLE
Update copyright  headers, maven config to the parent pom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -109,7 +109,7 @@
                 <version>2.1</version>
                 <configuration>
                     <spec>
-                        <specVersion>3.1</specVersion>
+                        <specVersion>${spec.version}</specVersion>
                         <specImplVersion>${project.version}</specImplVersion>
                         <apiPackage>jakarta.jms</apiPackage>
                     </spec>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,14 @@
 
     <name>Jakarta Messaging</name>
     <description>Jakarta Messaging Parent</description>
+
+    <properties>
+        <!-- spec.status: DRAFT, BETA, etc., or "Final Release for final -->
+        <spec.status>DRAFT</spec.status>
+        <!-- Version of the specification in the generated documents. Should be x.y for final version, not x.y.z -->
+        <spec.version>3.1</spec.version>
+    </properties>
+    
     <url>https://projects.eclipse.org/projects/ee4j.jms</url>
     <licenses>
         <license>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -47,8 +47,10 @@
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jruby.version>9.2.11.1</jruby.version>
-        <!-- status: DRAFT, BETA, etc., or "Final Release for final -->
-        <status>DRAFT</status>
+        <!-- spec.status: DRAFT, BETA, etc., or "Final Release for final -->
+        <spec.status>DRAFT</spec.status>
+        <!-- Version of the specification in the generated documents. Should be x.y for final version, not x.y.z -->
+        <spec.version>${project.version}</spec.version>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>
@@ -86,10 +88,10 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <outputFile>${project.build.directory}/generated-docs/messaging-spec-${project.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-messaging-spec-${spec.version}.html</outputFile>
                             <attributes>
                                 <doctype>book</doctype>
-                                <status>${status}</status>
+                                <status>${spec.status}</status>
                                 <data-uri />
                                 <icons>font</icons>
                                 <toc>left</toc>
@@ -110,12 +112,12 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
-                            <outputFile>${project.build.directory}/generated-docs/messaging-spec-${project.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-messaging-spec-${spec.version}.pdf</outputFile>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/main/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
                                 <doctype>book</doctype>
-                                <status>${status}</status>
+                                <status>${spec.status}</status>
                                 <data-uri />
                                 <icons>font</icons>
                                 <pagenums />
@@ -135,8 +137,8 @@
                     <sourceDocumentName>messaging-spec.adoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>
-                        <revnumber>${project.version}</revnumber>
-                        <revremark>${status}</revremark>
+                        <revnumber>${spec.version}</revnumber>
+                        <revremark>${spec.status}</revremark>
                         <revdate>${revisiondate}</revdate>
                     </attributes>
                 </configuration>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -47,7 +47,7 @@
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jruby.version>9.2.11.1</jruby.version>
-        <!-- status: DRAFT, BETA, etc., or blank for final -->
+        <!-- status: DRAFT, BETA, etc., or "Final Release for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -47,10 +47,6 @@
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jruby.version>9.2.11.1</jruby.version>
-        <!-- spec.status: DRAFT, BETA, etc., or "Final Release for final -->
-        <spec.status>DRAFT</spec.status>
-        <!-- Version of the specification in the generated documents. Should be x.y for final version, not x.y.z -->
-        <spec.version>${project.version}</spec.version>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -11,7 +11,7 @@ Release: {revdate}
 
 == Copyright
 
-Copyright (c) 2019, 2020 Eclipse Foundation.
+Copyright (c) 2019, 2022 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 

--- a/spec/src/main/asciidoc/messaging-spec.adoc
+++ b/spec/src/main/asciidoc/messaging-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, 2021 Contributors to the Eclipse Foundation
+// Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
 //
 
 = Jakarta Messaging


### PR DESCRIPTION
* Updated copyrights to 2022
* Spec status should be Final Release for final, not blank - the generated document doesn't make sense if it's blank
* Generated spec documents renamed to be in line with what the release review expects
* Moved spec status and version properties to the parent pom to have them in the same place