### PR TITLE
Staged API shouldn't depend on having a staged jms-parent

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,14 +22,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.ee4j.jms</groupId>
-        <artifactId>jms-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.7</version>
     </parent>
 
     <groupId>jakarta.jms</groupId>
     <artifactId>jakarta.jms-api</artifactId>
-
+    <version>3.1.0-SNAPSHOT</version>
     <name>Jakarta Messaging API</name>
     <description>
         Jakarta Messaging describes a means for Java applications to create, send, 
@@ -53,6 +53,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>11</maven.compiler.release>
+        <!-- Version of the specification in the generated documents. Should be x.y for final version, not x.y.z -->
+        <spec.version>3.1</spec.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Workaround org.eclipse.ee4j.jms:jms-parent:pom:3.1.0 not being available in stage repo as per [Messaging mailing list discussion](https://www.eclipse.org/lists/messaging-dev/msg00048.html).

CC @arjantijms 