### PR TITLE
Fix entry in 'relationship between interfaces'

### DIFF
--- a/spec/src/main/asciidoc/messaging-spec.adoc
+++ b/spec/src/main/asciidoc/messaging-spec.adoc
@@ -478,7 +478,7 @@ messaging |Domain-specific API for pub/sub messaging
 
 |Session | |QueueSession |TopicSession
 
-|MessageProducer |JMSProducer |QueueSender |QueueReceiver
+|MessageProducer |JMSProducer |QueueSender |TopicPublisher
 |===
 
 === Terminology for sending and receiving messages


### PR DESCRIPTION
`QueueReceiver` doesn't seem to correspond to `MessageProducer` well, so I propose to update

![image](https://github.com/jakartaee/messaging/assets/11896137/4b776871-08af-46c7-b7ab-da69662a65dd)

to

![image](https://github.com/jakartaee/messaging/assets/11896137/76fe19a8-e90d-419f-89ba-3036b9c4f2b8)
