### PR TITLE
Drop unused resource declaration

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
-    Copyright 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright 2021, 2025 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,14 +71,6 @@
         <resources>
             <resource>
                 <directory>${project.basedir}/..</directory>
-                <includes>
-                    <include>LICENSE.md</include>
-                    <include>NOTICE.md</include>
-                </includes>
-                <targetPath>META-INF</targetPath>
-            </resource>
-            <resource>
-                <directory>${project.basedir}</directory>
                 <includes>
                     <include>LICENSE.md</include>
                     <include>NOTICE.md</include>


### PR DESCRIPTION
Observed before this change:
```
[INFO] --- resources:3.3.1:resources (default-resources) @ jakarta.jms-api ---
[INFO] Copying 2 resources from .. to target/classes/META-INF
[INFO] Copying 0 resource from  to target/classes/META-INF
```