### PR TITLE
Fix example with special meaning of _ escaped

### DIFF
--- a/spec/src/main/asciidoc/messaging-spec.adoc
+++ b/spec/src/main/asciidoc/messaging-spec.adoc
@@ -1449,7 +1449,7 @@ character is used to escape the special meaning of the '_' and '%' in
 pattern-value.)
 ** "phone LIKE '12%3'" is true for '123' or '12993' and false for '1234'
 ** "word LIKE 'l_se'" is true for 'lose' and false for 'loose'
-** "underscored LIKE '_%' ESCAPE '\'" is true for '_foo' and false for
+** "underscored LIKE '\_%' ESCAPE '\'" is true for '_foo' and false for
 'bar'
 ** "phone NOT LIKE '12%3'" is false for '123' and '12993' and true for
 '1234'


### PR DESCRIPTION
The current
![image](https://github.com/user-attachments/assets/1b7d8218-cd83-41e6-aa63-ed9ebfcfacb9)
seems not right (as the escape is not used and it's `true` for _bar_...

JSR-343 is
![image](https://github.com/user-attachments/assets/7ce0ffa5-13d3-4741-8c39-451dcb133294)
which I'm proposing to restore here.